### PR TITLE
fix: segfault when unknown flag were passed

### DIFF
--- a/truth/truth.c
+++ b/truth/truth.c
@@ -7,37 +7,58 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <unistd.h>
 #include <ctype.h>
 
 #include "truth.h"
 
 bool verbose;
-
 static char inbuf[BUFSIZ];
+
+void handle_flags(const int argc, char *const *argv, char **text)
+{
+    /* see: https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html */
+    const char *valid_flags = "v::";
+    char opt;
+
+    /* 
+     * no option passed
+     */
+    if (argc == 1) {
+		fgets(inbuf, BUFSIZ, stdin);
+		*text = inbuf;
+        return;
+    }
+
+    *text = argv[1];
+    while ((opt = getopt(argc, argv, valid_flags)) != -1) {
+        switch (opt) {
+            case 'v':
+                verbose = true;
+
+                /* 
+                 * if -v was first passed 
+                 * instead of table
+                 */
+                if (optarg) {
+                    *text = optarg;
+                }
+
+                break;
+            case '?':
+            default:
+                USAGE(argv[0], "<table> [-v]");
+                break;
+        }
+    }
+}
 
 int main(int argc, char **argv)
 {
 	char *text;
 	Statement *prg;
 
-	if (argc <= 1) {
-		fgets(inbuf, BUFSIZ, stdin);
-		text = inbuf;
-	} else {
-		if (strcmp(argv[1], "-v") == 0) {
-			verbose = true;
-
-			argv++;
-			argc--;
-		}
-
-		if (argc >= 2) {
-			text = argv[1];
-		} else {
-			fgets(inbuf, BUFSIZ, stdin);
-			text = inbuf;
-		}
-	}
+    handle_flags(argc, argv, &text);
 
 	LOG("==========[---PARSE TRACE BEGINS---]==========");
 	prg = parse(&text);

--- a/truth/truth.c
+++ b/truth/truth.c
@@ -17,8 +17,7 @@ static char inbuf[BUFSIZ];
 
 void handle_flags(const int argc, char *const *argv, char **text)
 {
-	/* see: https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html */
-	const char *valid_flags = "v::";
+	const char *valid_flags = "v:";
 	char opt;
 
 	/* 

--- a/truth/truth.c
+++ b/truth/truth.c
@@ -17,40 +17,40 @@ static char inbuf[BUFSIZ];
 
 void handle_flags(const int argc, char *const *argv, char **text)
 {
-    /* see: https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html */
-    const char *valid_flags = "v::";
-    char opt;
+	/* see: https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html */
+	const char *valid_flags = "v::";
+	char opt;
 
-    /* 
-     * no option passed
-     */
-    if (argc == 1) {
+	/* 
+	* no option passed
+	*/
+	if (argc == 1) {
 		fgets(inbuf, BUFSIZ, stdin);
 		*text = inbuf;
-        return;
-    }
+		return;
+	}
 
-    *text = argv[1];
-    while ((opt = getopt(argc, argv, valid_flags)) != -1) {
-        switch (opt) {
-            case 'v':
-                verbose = true;
+	*text = argv[1];
+	while ((opt = getopt(argc, argv, valid_flags)) != -1) {
+		switch (opt) {
+		case 'v':
+			verbose = true;
 
-                /* 
-                 * if -v was first passed 
-                 * instead of table
-                 */
-                if (optarg) {
-                    *text = optarg;
-                }
+			/* 
+			 * if -v was first passed 
+			 * instead of table
+			 */
+			if (optarg) {
+			    *text = optarg;
+			}
 
-                break;
-            case '?':
-            default:
-                USAGE(argv[0], "<table> [-v]");
-                break;
-        }
-    }
+			break;
+		case '?':
+		default:
+			USAGE(argv[0], "<table> [-v]");
+			break;
+		}
+	}
 }
 
 int main(int argc, char **argv)
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
 	char *text;
 	Statement *prg;
 
-    handle_flags(argc, argv, &text);
+	handle_flags(argc, argv, &text);
 
 	LOG("==========[---PARSE TRACE BEGINS---]==========");
 	prg = parse(&text);

--- a/truth/truth.c
+++ b/truth/truth.c
@@ -17,39 +17,29 @@ static char inbuf[BUFSIZ];
 
 void handle_flags(const int argc, char *const *argv, char **text)
 {
-	const char *valid_flags = "v:";
+	const char *valid_flags = "v";
 	char opt;
 
-	/* 
-	* no option passed
-	*/
-	if (argc == 1) {
+	while ((opt = getopt(argc, argv, valid_flags)) != -1) {
+		switch (opt) {
+		case 'v':
+			verbose = true;
+			break;
+		case '?':
+		default:
+			USAGE(argv[0], "[-v] <table>");
+			break;
+		}
+	}
+
+	if (argc == optind) {
 		fgets(inbuf, BUFSIZ, stdin);
 		*text = inbuf;
 		return;
 	}
 
-	*text = argv[1];
-	while ((opt = getopt(argc, argv, valid_flags)) != -1) {
-		switch (opt) {
-		case 'v':
-			verbose = true;
-
-			/* 
-			 * if -v was first passed 
-			 * instead of table
-			 */
-			if (optarg) {
-			    *text = optarg;
-			}
-
-			break;
-		case '?':
-		default:
-			USAGE(argv[0], "<table> [-v]");
-			break;
-		}
-	}
+	/* program text is in remaining argv */
+	*text = argv[optind];
 }
 
 int main(int argc, char **argv)

--- a/truth/truth.h
+++ b/truth/truth.h
@@ -5,6 +5,10 @@
 	fprintf(stderr, "Error: %s\n", msg);  \
 	exit(1)
 
+#define USAGE(progn, usg)                              \
+	fprintf(stderr, "Usage: %s %s\n", progn, usg);  \
+	exit(1)
+
 #ifndef NOLOG
 #define LOG(msg) \
 	if (verbose) { fprintf(stderr, "%d:\t%s\n", __LINE__, msg); }


### PR DESCRIPTION
How to reproduce:

- ./truth -h # any invalid flag
- segfault

This problem can be solved by checking if argv[1] starts with '-'.

```c
if (strcmp(argv[1], "-v") == 0) {
    verbose = true;

    argv++;
    argc--;
} else if (*argv[1] == '-') {
    /* ERR("unknown flag"); */
    fprintf(stderr, "Error: unknown flag -%c\n", *++argv[1]);
    return EXIT_FAILURE;
}
```

But then comes up a new problem which is, if -v were passed after table, truth won't verbose. This occurs because truth expect -v to present **BEFORE** table were passed.

The new problem is easy to fix but you'll just make the program harder to read.

A simple solution is to use functions like getopt(3), getopt_long(3), or functions in header <argp.h> see: [https://www.gnu.org/software/libc/manual/html_node/Argp.html](https://www.gnu.org/software/libc/manual/html_node/Argp.html) or even make your own function.

> Be aware that the line (specifically "::") `const char *valid_flags = "v::"` is part of
GNU extension, see: [https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html](https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html)